### PR TITLE
Add crontab task that updates the ssl certificate once a day

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,18 @@ RUN pip install cx-Oracle \
     && ldconfig
 ENV LD_LIBRARY_PATH=/opt/oracle/instantclient_19_9
 
+RUN apt-get update && apt-get install -y cron
+
+
+# Copy crontab file to the cron.d directory
+COPY crontab /etc/cron.d/crontab
+
+# Give execution rights on the cron job
+RUN chmod 0644 /etc/cron.d/crontab
+
+# Apply cron job
+RUN crontab /etc/cron.d/crontab
+
 ARG SLL_URL=https://noharm.ai/ssl
 
 RUN wget -c $SLL_URL/fullchain.pem -P /etc/ssl --no-check-certificate
@@ -26,3 +38,9 @@ RUN pip install --upgrade pip
 RUN pip install -r ./requirements.txt
 
 COPY ./app /app
+
+# Create the log file if needed for debug, uncomment crontab file as well
+# RUN touch /var/log/cron.log
+
+# Give execution rights on the task script
+RUN chmod 0744 /app/renew_cert.sh

--- a/app/prestart.sh
+++ b/app/prestart.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# This file is loaded by the /entrypoint.sh script from tiangolo/uwsgi-nginx-flask
+# Reference: https://github.com/tiangolo/uwsgi-nginx-docker#custom-appprestartsh
+
+# start cron
+cron

--- a/app/renew_cert.sh
+++ b/app/renew_cert.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SLL_URL=https://noharm.ai/ssl
+
+wget -q $SLL_URL/fullchain.pem -O /etc/ssl/fullchain.pem --no-check-certificate
+wget -q $SLL_URL/privkey.pem -O /etc/ssl/privkey.pem --no-check-certificate
+wget -q $SLL_URL/ssl-dhparams.pem -O /etc/ssl/ssl-dhparams.pem --no-check-certificate
+
+/usr/sbin/service nginx reload

--- a/crontab
+++ b/crontab
@@ -1,0 +1,2 @@
+0 3 * * * /bin/bash /app/renew_cert.sh #  >> /var/log/cron.log 2>&1
+# This empty line is required


### PR DESCRIPTION
I created the script that copy the new certificate files to local.
It will always fetch the certificate files and overwrite the local ones.
There is an option with wget -N that only fetch and overwrite if the remote file is new. That's an alternative.
I installed cron, copy the crontab to /etc and started cron. It is configured to run at 3am every day. 

PS.:
I created a new file at /app/prestart.sh to start cron on startup. This replaces the default file...
https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/app/prestart.sh
But I don't think we need any of these command from the default file.