### PR TITLE
Ajustar para mssql

### DIFF
--- a/app/resources/connections.py
+++ b/app/resources/connections.py
@@ -32,6 +32,7 @@ elif TYPE == "firebird":
 
 
 else:
+    TYPE = "mssql+pymssql" if TYPE == "mssql" else TYPE
     url_object = URL.create(
         TYPE, username=USER, password=PASS, host=HOST, database=DATABASE, port=PORT
     )


### PR DESCRIPTION
Alteração permite que a DB_TYPE utilizada no .env seja simplesmente "mssql" ao invés de "mssql+pymssql"