### PR TITLE
Connections: support for mysql

### DIFF
--- a/app/resources/connections.py
+++ b/app/resources/connections.py
@@ -31,6 +31,8 @@ if TYPE == "oracle":
 elif TYPE == "firebird":
     url_object = f"firebird+fdb://{USER}:{PASS}@{HOST}:{PORT}/{DATABASE}"
 
+elif TYPE == "mysql":
+    url_object = f"mysql+pymysql://{USER}:{PASS}@{HOST}:{PORT}/{DATABASE}"
 
 else:
     TYPE = "mssql+pymssql" if TYPE == "mssql" else TYPE

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ greenlet<0.5,>=0.4.5
 psycopg2==2.9.6
 psycopg2-binary==2.9.6
 pymssql==2.2.7
+pymysql==1.1.1
 python-dotenv==1.0.0
 pyopenssl
 SQLAlchemy==2.0.18


### PR DESCRIPTION
@marceloarocha Fiz esse ajuste para instalar num cliente que é MySQL e estava com uma versão antiga.
Tive que fazer mais ajustes específicos direto no container deles, mas agora funcionou até a rota do múltiplo. Abs!